### PR TITLE
Set module scope PhysX after the await

### DIFF
--- a/src/physics.js
+++ b/src/physics.js
@@ -462,7 +462,7 @@ AFRAME.registerSystem('physx', {
     let self = this;
     let resolveInitialized;
     let initialized = new Promise((r, e) => resolveInitialized = r)
-    PhysX = PHYSX({
+    let instance = PHYSX({
         locateFile() {
             return self.findWasm()
         },
@@ -470,8 +470,9 @@ AFRAME.registerSystem('physx', {
           resolveInitialized();
         }
       });
-    if (PhysX instanceof Promise) PhysX = await PhysX;
-    this.PhysX = PhysX;
+    if (instance instanceof Promise) instance = await instance;
+    this.PhysX = instance;
+    PhysX = instance;
     await initialized;
     self.startPhysXScene()
     self.physXInitialized = true


### PR DESCRIPTION
This fixes the error
`Cannot use 'in' operator to search for 'eY' in undefined` when using
`joint.setAttribute("physx-joint-constraint__y", "constrainedAxes: y; linearLimit: 0 3; stiffness: 3");`