### PR TITLE
Update ammo example to 1.7.0 as well.

### DIFF
--- a/examples/pinboard/ammo.html
+++ b/examples/pinboard/ammo.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8">
     <title>Physics Benchmark Test - Ammo</title>
     <meta name="description" content="Physics Benchamrk Test - Ammo">
-    <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script>
+    <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/MozillaReality/ammo.js@8bbc0ea/builds/ammo.wasm.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-physics-system@4.2.2/dist/aframe-physics-system.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-physics-system@4.2.3/dist/aframe-physics-system.js"></script>
     <script src="./pinboard.js"></script>
     <link rel="stylesheet" href="../../styles.css">
   </head>


### PR DESCRIPTION
This is now possible with aframe-physics-system 4.2.3, which is compatible with A-Frame 1.6.0+ (including stats)