### PR TITLE
Fix local development to rebuild dist on change and use local wasm file

### DIFF
--- a/src/physics.js
+++ b/src/physics.js
@@ -329,7 +329,7 @@ AFRAME.registerSystem('physx', {
     speed: {default: 1.0},
 
     // URL for the PhysX WASM bundle.
-    wasmUrl: {default: "https://cdn.jsdelivr.net/gh/c-frame/physx/wasm/physx.release.wasm"},
+    wasmUrl: {default: "../../wasm/physx.release.wasm"},
 
     // If true, sets up a default scene with a ground plane and bounding
     // cylinder.
@@ -473,6 +473,7 @@ AFRAME.registerSystem('physx', {
     if (instance instanceof Promise) instance = await instance;
     this.PhysX = instance;
     PhysX = instance;
+    globalThis.PhysX = instance;
     await initialized;
     self.startPhysXScene()
     self.physXInitialized = true

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,7 +12,7 @@ module.exports = {
   // Webpack will bundle all JavaScript into this file
   output: {
     path: path.resolve(__dirname, 'dist'),
-    publicPath: '',
+    publicPath: '/dist/',
     filename: 'physx.js'
   },
 


### PR DESCRIPTION
I changed the default url from
`https://cdn.jsdelivr.net/gh/c-frame/physx/wasm/physx.release.wasm`
to 
`../../wasm/physx.release.wasm`
so that it works correctly on local dev on this repo where the examples don't define the wasmUrl.

Each project needs to define the wasmUrl property otherwise the project will just break when we'll release a new physx version with an updated wasm file. For example using physx 0.1.3 and using default `https://cdn.jsdelivr.net/gh/c-frame/physx/wasm/physx.release.wasm` url will just break your experience with an error `"Uncaught (in promise) RuntimeError: null function or function signature mismatch"` when 0.1.4 will be released with an updated wasm file.

Be sure to use in your project right now a specific version:
```html
<script src="https://cdn.jsdelivr.net/gh/c-frame/physx@v0.1.3/dist/physx.min.js"></script>
<a-scene
    physx="autoLoad: true; delay: 1000; wasmUrl: https://cdn.jsdelivr.net/gh/c-frame/physx@v0.1.3/wasm/physx.release.wasm; useDefaultScene: false;"
```